### PR TITLE
ci: add compose validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Validate YAML syntax
-        run: python3 -c "import yaml, sys; yaml.safe_load(open('docker-compose.yml')); print('docker-compose.yml: valid')"
+        run: |
+          python3 -c "import yaml; yaml.safe_load(open('docker-compose.yml'))"
       - name: Validate compose spec
         run: docker compose config --quiet
         env:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,30 @@
+name: Validate compose
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+      - develop
+  pull_request:
+    branches:
+      - main
+      - staging
+      - develop
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Validate YAML syntax
+        run: python3 -c "import yaml, sys; yaml.safe_load(open('docker-compose.yml')); print('docker-compose.yml: valid')"
+      - name: Validate compose spec
+        run: docker compose config --quiet
+        env:
+          POSTGRES_USER: ci
+          POSTGRES_PASSWORD: ci
+          POSTGRES_DB: ci
+          STELLAR_AUTH_JWT_SECRET: ci-placeholder-pad-to-32-chars-ok
+          STELLAR_HTTP_CORS_ORIGIN: http://localhost:3000


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/validate.yml` — validates `docker-compose.yml` syntax on push and PRs to `main`, `staging`, and `develop`

## Test plan

- [ ] CI passes on this PR
- [ ] Validate step passes after merge to `develop`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)