### PR TITLE
chore: back-merge main's unique CI + ADR into develop (kill main-ahead drift)

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -5,16 +5,16 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        branch: [main, staging, develop]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -24,8 +24,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote add upstream https://github.com/orphic-inc/stellar-compose.git
 
-      - name: Sync ${{ matrix.branch }}
+      - name: Sync main from upstream
         run: |
           git fetch upstream
-          git checkout -B ${{ matrix.branch }} upstream/${{ matrix.branch }}
-          git push origin ${{ matrix.branch }} --force
+          git rebase upstream/main
+          git push origin main --force-with-lease

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,31 @@
+name: Sync from upstream
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [main, staging, develop]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote add upstream https://github.com/orphic-inc/stellar-compose.git
+
+      - name: Sync ${{ matrix.branch }}
+        run: |
+          git fetch upstream
+          git checkout -B ${{ matrix.branch }} upstream/${{ matrix.branch }}
+          git push origin ${{ matrix.branch }} --force

--- a/docs/adr/0001-pin-container-images.md
+++ b/docs/adr/0001-pin-container-images.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+date: 2026-06-09
+---
+
+# Pin all container images; never run floating tags in the fleet
+
+## Context
+
+`stellar-api`'s Dockerfile built `FROM node:lts-alpine` — a floating tag. With no
+change on our side, that tag advanced to **Alpine 3.23** (OpenSSL 3 only). Prisma
+5.3.1 misdetects libssl on Alpine 3.21+ and falls back to its `openssl-1.1.x`
+engine, which needs `libssl.so.1.1` — absent on 3.23. The API crash-looped. CI
+stayed green the whole time, because `validate.yml` only runs `docker compose
+config` (spec validation) — it never builds or boots. The break was invisible
+until a human ran the stack.
+
+## Decision
+
+Every image in the fleet is pinned to an explicit, reproducible reference — no
+`:latest`, no distro-floating base tags. Pins are kept fresh by an automated bump
+bot, not by drift.
+
+- `api`: base image pinned to `node:24-alpine3.23` (orphic-inc/stellar-api#100).
+- `ui` (`…stellar-ui:latest`) and `db` (`postgres:16-alpine`, whose `-alpine`
+  suffix floats the distro): pin — tracked in #8.
+- Automated bump PRs (Renovate, Docker + npm) — tracked in #9.
+- A build + boot + migrate CI smoke test, to catch the class of break that
+  config-only validation misses — tracked in #7.
+
+## Consequences
+
+A floating tag trades reproducibility for silent, unscheduled change: the same
+commit builds differently tomorrow, and a distro/engine break arrives with no
+diff to blame. Pinning makes the runtime an explicit, reviewable input. The
+cost — pins go stale — is paid down by the bump bot, which turns "drift
+discovered by crash" into "drift proposed as a reviewable PR" gated by a CI boot.
+
+The non-obvious trap this ADR exists to prevent: a future reader sees
+`node:24-alpine3.23` and "tidies" it back to `node:lts-alpine`. **Don't** — that
+is the exact change that caused the outage. Bump a pin deliberately, via a bump
+PR, with CI booting the stack.


### PR DESCRIPTION
Per ADR-0009 (main must never run ahead of develop). main carried 3 genuinely-unique commits develop lacked — back-merged here so the drift dies without a release:

- `docs(adr): 0001 — pin all container images; no floating tags`
- `ci: add upstream sync workflow`
- `ci: simplify fork sync — rebase main only`

Skipped the main-only submodule-pointer bump (`e46e37f`) — develop manages its own. After this, main is no longer content-ahead of develop.