### PR TITLE
docs(dx): operator runbook + fix broken image refs / env drift (Workstream C)

### DIFF
--- a/.env.api
+++ b/.env.api
@@ -11,3 +11,22 @@ STELLAR_SMTP_PORT=
 STELLAR_SMTP_USER=
 STELLAR_SMTP_PASS=
 STELLAR_SMTP_FROM=
+# Optional Sentry — if unset, error reporting is disabled
+STELLAR_SENTRY_DSN=
+# Site identity + Golden Rules ${...} token resolution (PRD-09 / ADR-0020).
+# All optional — sane defaults apply. STELLAR_PUBLIC_KB_BASE is the Stellar
+# Public KB root (public-facing wiki) hosting the policy/guidance articles.
+STELLAR_SITE_NAME=Stellar
+STELLAR_IRC_URL=/irc
+STELLAR_DISABLED_CHANNEL=#disabled
+STELLAR_STAFFPM_PATH=/inbox/staff
+STELLAR_PUBLIC_KB_BASE=https://kb.stellargra.ph
+# korin.pink IRC integration (ADR-0013). The app runs fine WITHOUT korin —
+# each path is inert / fails closed until its keys are set. Leave blank to
+# run without the IRC sidecar.
+# KORIN_API_URL/KORIN_PULL_KEY: stellar→korin (metrics pull + announce push).
+# STELLAR_SERVICE_KEY: bearer korin→stellar (nick lookup, link, reputation).
+KORIN_API_URL=
+KORIN_PULL_KEY=
+KORIN_POLL_INTERVAL_MS=300000
+STELLAR_SERVICE_KEY=

--- a/README.md
+++ b/README.md
@@ -1,36 +1,103 @@
 # Stellar Compose
 
-This is a Docker compose file which ties together the API and UI for Stellar.
+The deployment and orchestration repo for **Stellar** — the Docker Compose stack that ties the API, UI, and database together. This is the operator's home: stand up, operate, upgrade, and back up a Stellar instance from here.
 
-## Quick Start
+## The Stellar constellation
 
-Make sure you have the following installed and working:
+Stellar is four repositories developed together:
 
-- Docker
-- Git
+| Repo | Role |
+| --- | --- |
+| [stellar-api](https://github.com/orphic-inc/stellar-api) | Node/Express/Prisma REST API — the platform backend. Self-migrating container. |
+| [stellar-ui](https://github.com/orphic-inc/stellar-ui) | React SPA frontend + the nginx proxy that fronts the stack. |
+| **stellar-compose** (this repo) | The Compose stack + operator runbook — deployment, image pinning, upgrades. |
+| [korin.pink](https://github.com/obrien-k/korin-pink) | **Optional** external IRC-metrics sidecar. The app runs fine without it. |
 
-The following commands will set up a new development environment using Docker.
+The publish/deploy boundary is defined in [stellar-api ADR-0027](https://github.com/orphic-inc/stellar-api/blob/main/docs/adr/0027-publish-vs-deploy-boundary.md): the api/ui pipelines end at a versioned GHCR image publish; **this repo owns deployment** — it pins which published image tags run, and promotion/rollback is a pin change here.
 
-    git clone https://github.com/orphic-inc/stellar-compose stellar
-    cd stellar
-    git submodule update --init --recursive
+## Quick Start (local build)
 
-Now, edit `.env.api` and replace all relevant configuration. Refer to [API](https://github.com/orphic-inc/stellar-api) documentation on the keys and values. Then, edit `.env.ui` and do the same with the [UI](https://github.com/orphic-inc/stellar-api) documentation. Finally, run the following to start Stellar:
+Prerequisites: **Docker** and **Git**.
 
-    docker compose up --build -d
+```bash
+git clone https://github.com/orphic-inc/stellar-compose stellar
+cd stellar
+git submodule update --init --recursive
+```
+
+Edit `.env.api`, `.env.ui`, and `.env.db` — replace the `changeme` placeholders (see the [API](https://github.com/orphic-inc/stellar-api) and [UI](https://github.com/orphic-inc/stellar-ui) docs for the keys). At minimum set `STELLAR_AUTH_JWT_SECRET` (32+ chars) and the database credentials. Then build and start:
+
+```bash
+docker compose up --build -d
+```
+
+This builds the API and UI from the submodules. For a **pulled-image** deployment (production), see [Deploying a release](#deploying-a-release) below.
+
+## First-run setup (required)
+
+A fresh instance is **not usable until two one-time steps are done**:
+
+1. **Schema** — applied automatically. The api container self-migrates on boot: its entrypoint runs `prisma migrate deploy` before starting (stellar-api #276), so you never run migrations by hand.
+2. **Seed defaults** — **not automatic yet.** The entrypoint applies migrations but does **not** plant the default user ranks, forums, Golden Rules, System user, or stylesheet fixtures. Until they exist the app can't assign ranks or show forums. Seed them once against the running database:
+
+   ```bash
+   docker compose exec api npm run db:seed
+   ```
+
+   > Wiring an idempotent seed into first boot is a tracked follow-up (see [Known rough edges](#known-rough-edges)); until then this is a manual step on a new instance.
+
+3. **Create the first admin** — the API is 503-walled on `/api/*` until the one-time install mints the first SysOp (stellar-api ADR-0022). Open the site and complete the install form, or POST directly:
+
+   ```bash
+   curl -X POST https://<your-host>/api/install \
+     -H 'Content-Type: application/json' \
+     -d '{"username":"admin","email":"admin@example.com","password":"<strong-password>"}'
+   ```
+
+## Deploying a release
+
+Production runs **pulled, pinned images** — not local builds and not `:latest`. In `docker-compose.yml`, each service has an `image:` line pinned to a published semver and a commented `build:` line:
+
+```yaml
+image: ghcr.io/orphic-inc/stellar-api:0.6.9
+# build: ./api
+```
+
+- **Deploy / upgrade** — bump the pinned tag to the target version and `docker compose pull && docker compose up -d`. The api container self-migrates the schema forward on boot.
+- **Roll back** — revert the pin to the previous tag and `pull && up -d` again. Because the pin is tracked in git, a deploy and its rollback are both reviewable commits (ADR-0027).
+- **Never pin `:latest` in production** — it makes deploys non-reproducible and rollbacks impossible.
+
+Published tags live at `ghcr.io/orphic-inc/stellar-api` and `ghcr.io/orphic-inc/stellar-ui`. (Version parity between api and ui is a work in progress — pin each to its own latest published tag.)
+
+> **Destructive migrations — read before a major upgrade.** The api self-migrates on boot with `prisma migrate deploy`. Stellar uses an **expand → contract** discipline (stellar-api ADR-0027): a migration that drops or rewrites columns ships one release *after* the code that stopped needing the old shape. Do not skip intermediate releases across a known destructive migration, and take a backup first (below). Running more than one api replica through a destructive migration is not yet safe — see [Known rough edges](#known-rough-edges).
+
+## Backup & restore
+
+The database lives in a Docker volume mounted into the `db` service. Back it up with `pg_dump` before any upgrade and on a schedule:
+
+```bash
+# Backup
+docker compose exec -T db pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" > stellar-$(date +%F).sql
+
+# Restore (into a fresh, empty database)
+docker compose exec -T db psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" < stellar-YYYY-MM-DD.sql
+```
+
+Store backups off-host. A destructive migration or a lost volume with no backup is unrecoverable.
 
 ## TLS
 
-In order to provide an HTTPS endpoint, you must provide the proxy container with certificates. These can come from [LetsEncrypt](https://letsencrypt.org/) or a commercial certificate issuer.
+To serve HTTPS, provide the proxy container with certificates (from [Let's Encrypt](https://letsencrypt.org/) or a commercial issuer):
 
-1. Place the following files in `./volumes/proxy-certs`
-
-    * `cert.pem` - Your domain certificate
-    * `privkey.pem` - Private key used to generate the certificate
-    * `chain.pem` - Intermediate and Root CA certificate chain
-
+1. Place `cert.pem` (domain cert), `privkey.pem` (private key), and `chain.pem` (CA chain) in `./volumes/proxy-certs`.
 2. Uncomment the `proxy-tls.nginx.conf` volume mapping and comment the default config mapping in `docker-compose.yml`.
 
-## Docker Images
+## The korin.pink IRC sidecar (optional)
 
-If you would prefer to use a tagged image, comment/uncomment `build` and `image` lines in `docker-compose.yml` to switch between locally built and remotely downloaded images. The `latest` tag represents the `main` branch of each repo, and tagged versions are available by their version number, e.g. `v1.0.0`.
+Stellar runs fully without IRC. The korin integration is inert until you set its keys in `.env.api` (`KORIN_API_URL`, `KORIN_PULL_KEY`, `STELLAR_SERVICE_KEY`); leave them blank to run without it. See [stellar-api ADR-0013](https://github.com/orphic-inc/stellar-api/blob/main/docs/adr/0013-korin-pink-irc-integration.md).
+
+## Known rough edges
+
+- **Seeding is a manual first-run step** (above) — an idempotent seed-on-first-boot is not yet wired into the entrypoint.
+- **Multi-replica migration safety** — the self-migrating entrypoint races if more than one api replica starts simultaneously against an unmigrated database ([issue #10](https://github.com/orphic-inc/stellar-compose/issues/10)). Single-replica deploys are unaffected.
+- **Boot smoke test** — CI validates `docker compose config` but does not yet build-and-boot the stack ([issue #7](https://github.com/orphic-inc/stellar-compose/issues/7)); that gap is how the malformed image references (fixed in this pass) went unnoticed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,11 @@
 version: "3.9"
 services:
   api:
-    image: ghcr.io/orphic-stellar-api:latest
-    build: ./api
+    # Pin a published semver, not :latest (ADR-0027). Bump this to promote a
+    # release; roll back by reverting the pin. To build locally instead,
+    # comment `image:` and uncomment `build:`.
+    image: ghcr.io/orphic-inc/stellar-api:0.6.9
+    # build: ./api
     restart: always
     env_file:
       - .env.api
@@ -12,8 +15,10 @@ services:
     networks:
       - internal
   ui:
-    image: ghcr.io/orphic/stellar-ui:latest
-    build: ./ui
+    # 0.6.3 is the latest published stellar-ui image; bump to 0.6.9 once the
+    # ui release cut catches up to the api (version parity). See ADR-0027.
+    image: ghcr.io/orphic-inc/stellar-ui:0.6.3
+    # build: ./ui
     restart: always
     env_file:
       - .env.ui


### PR DESCRIPTION
Part of the v0.7.0 developer & administrator experience epic. **Workstream C — stellar-compose** (the operator's home).

## Correctness fixes (were deploy-breaking)
- **Malformed image refs** — `ghcr.io/orphic-stellar-api:latest` (missing the `orphic-inc/` owner) and `ghcr.io/orphic/stellar-ui:latest` (wrong org). Both are masked today only because `build:` is also set; the moment an operator switches to pulled images (the production path) both pulls fail. Fixed to `ghcr.io/orphic-inc/...` and **pinned to published semvers** (api `0.6.9`, ui `0.6.3`) per ADR-0027, with `build:` kept commented for local dev.
- **`.env.api` drift** — restored the optional keys that had fallen out of sync with the api's `.env.default`: Sentry, the site-identity / Golden-Rules tokens, and the korin.pink IRC keys — each documented as optional / inert-until-set.

## Doc authoring — the operator runbook
The README grows from a dev-build note into the operator's home: the **constellation map** (4 repos), **first-run setup** (self-migrate + the manual seed + the `/install` 503-wall), **release deploy / upgrade / rollback** via pinned semvers, the **expand→contract destructive-migration caveat**, **backup/restore**, the **optional korin sidecar**, and a **known rough edges** section (manual seed, multi-replica #10, boot smoke #7).

## Notes
- **Left untouched:** the `version:` key and the db-volume lines — those are the separate named-volume work in progress on the fork; this PR only touches the image-ref lines, so the two are complementary.
- **ui pin is `0.6.3`** (its latest published image); it bumps to `0.6.9` once the ui release catches up to the api (version parity — a paired follow-up).
- `docker compose config` valid.