### PR TITLE
docs(compose): agent + contributor guides (salvaged from #12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md — stellar-compose
+
+Docker Compose orchestration for the Stellar platform. Ties together stellar-api, stellar-ui, and a Postgres database. This file is the agent guide; the human operator runbook is [README.md](README.md).
+
+## Submodule architecture
+
+```
+stellar-compose/
+  api/   → git submodule → orphic-inc/stellar-api  (pinned SHA)
+  ui/    → git submodule → orphic-inc/stellar-ui   (pinned SHA)
+  docker-compose.yml
+  .env.api   .env.ui   .env.db
+```
+
+After cloning, initialize submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+To pull the latest upstream commit for a submodule:
+
+```bash
+git submodule update --remote api   # or ui
+git add api                         # records the new SHA
+git commit -m "chore: bump api submodule to <short-sha>"
+```
+
+Submodules are pinned to exact SHAs; the recorded SHA in `.gitmodules` and the index is what matters. The submodule pin only affects the `build:` (local-build) path — a **pulled** deploy uses the `image:` tag, not the submodule. When you do bump the api submodule, pin a **current** commit (post the self-migrating entrypoint, stellar-api #276) — an old pin regresses local builds to manual migrations.
+
+## Images: pin a semver, don't ship `:latest`
+
+CI in each service repo publishes images on push to `main` (`:latest`) and on version tags (`:<semver>`). **Production pins a specific semver in `docker-compose.yml` — never `:latest`** ([stellar-api ADR-0027](https://github.com/orphic-inc/stellar-api/blob/main/docs/adr/0027-publish-vs-deploy-boundary.md)): a pin is a reproducible, revertible deploy; `:latest` is not.
+
+| Use | image line |
+|---|---|
+| Production / staging | `image: ghcr.io/orphic-inc/stellar-api:0.6.9` (pinned semver) |
+| Local build from submodule source | comment `image:`, uncomment `build: ./api` |
+| Throwaway "track main" (never prod) | `:latest` |
+
+Deploy/upgrade = bump the pin and `docker compose pull && up -d`; roll back = revert the pin. The api container self-migrates on boot (#276).
+
+## Compose for local dev — when to use it
+
+You usually don't need compose for day-to-day development:
+
+- **Developing api only**: run `npm run dev` in `stellar-api`. No compose.
+- **Developing ui only**: run `npm start` in `stellar-ui` (proxies `/api` → `localhost:8080`). No compose.
+- **Integration / E2E testing**: use compose to spin up the full stack against real images before a release.
+- **Production deploys**: the only context where you're running the published images.
+
+## Environment files
+
+| File | Purpose |
+|---|---|
+| `.env.api` | stellar-api env vars (mirror `api/.env.default`) |
+| `.env.ui` | stellar-ui env vars (copy from `ui/.env.example`) |
+| `.env.db` | Postgres credentials (`POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`) |
+
+`.env.api` must set at minimum `STELLAR_PSQL_URI`, `STELLAR_AUTH_JWT_SECRET`, `STELLAR_HTTP_CORS_ORIGIN`. The full variable reference is [api `docs/README.md`](https://github.com/orphic-inc/stellar-api/blob/main/docs/README.md#environment-reference) (and `api/.env.default`). Keep a live secret only in your local `.env.api` — the committed copy stays `changeme`.
+
+## Commands
+
+```bash
+docker compose up --build -d   # build from submodule source and start
+docker compose up -d           # start using pulled/cached images
+docker compose logs -f api     # tail api logs
+docker compose exec api sh     # shell into the api container
+docker compose exec api npm run db:seed   # seed default ranks/forums (first run — see README)
+docker compose down            # stop and remove containers (data volume persists)
+docker compose down -v         # also wipe the db-data volume
+```
+
+## Cross-repo considerations
+
+Changes in stellar-api that alter response shapes, route paths, or the OpenAPI spec require a matching update in stellar-ui before compose produces a coherent stack. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full cross-repo checklist.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to Stellar Compose
+
+Compose is the orchestration layer — it pins submodule SHAs, manages environment files, and defines the production service topology. Most active development happens in stellar-api and stellar-ui; compose changes are typically submodule bumps, environment additions, image-pin updates, or nginx/TLS config changes.
+
+---
+
+## Workflow 1 — Daily development (no compose needed)
+
+Run services independently:
+
+```bash
+# Terminal 1 — API (localhost:8080)
+cd ../stellar-api && npm run dev
+
+# Terminal 2 — UI (localhost:9000, proxies /api → :8080)
+cd ../stellar-ui && npm start
+```
+
+Compose is not involved. This is the default for feature work.
+
+---
+
+## Workflow 2 — Cross-repo feature (API shape changes)
+
+When a stellar-api PR adds, removes, or renames a field in any response, or adds a new route that stellar-ui will consume:
+
+1. **In stellar-api**: implement the change, then export the updated spec.
+   ```bash
+   npm run openapi:export   # writes openapi.json to repo root
+   ```
+   Commit `openapi.json` in the same PR. CI enforces freshness — a stale spec fails the build.
+
+2. **In stellar-ui**: regenerate types from the new spec with `api:sync` (which pulls the fresh spec from the sibling `../stellar-api`; plain `api:generate` only reruns codegen over the already-vendored spec and won't pick up the change).
+   ```bash
+   # stellar-api must be a sibling directory:  ../stellar-api
+   npm run api:sync
+   npx tsc --noEmit          # verify no type regressions
+   ```
+   Commit `src/types/api.ts` (and `src/types/openapi.json`) in the UI PR. Link the API PR.
+
+3. **In stellar-compose** (after both PRs land on `main`): bump the submodule pins.
+   ```bash
+   git submodule update --remote api
+   git submodule update --remote ui
+   git add api ui
+   git commit -m "chore: bump api + ui submodules post <feature-name>"
+   ```
+
+Order matters: API merges first, UI types regenerate against the merged spec, then compose pins both together.
+
+---
+
+## Workflow 3 — Release
+
+1. In stellar-api, cut a version tag on `main` — CI publishes `ghcr.io/orphic-inc/stellar-api:<semver>` and refreshes `:latest`.
+2. Repeat for stellar-ui.
+3. In stellar-compose, point the `image:` pins at the new **semver** (not `:latest`), bump the submodule pins to the tagged commits, and tag compose itself:
+   ```bash
+   # Edit docker-compose.yml:  image: ghcr.io/orphic-inc/stellar-api:0.6.9  etc.
+   git add docker-compose.yml api ui
+   git commit -m "chore: release 0.6.9"
+   git tag v0.6.9 && git push origin v0.6.9
+   ```
+
+Production always runs a pinned semver, never `:latest` — a pin is a reproducible, revertible deploy ([stellar-api ADR-0027](https://github.com/orphic-inc/stellar-api/blob/main/docs/adr/0027-publish-vs-deploy-boundary.md)).
+
+---
+
+## Branch strategy
+
+All three repos are trunk-only: feature branches are cut from `main` and merged back via PR. Releases are cut as version tags on `main`. Compose pins its submodules to exact SHAs and its images to semver tags.
+
+| Branch / tag | Purpose | Image pin |
+|---|---|---|
+| `main` | trunk / development | `:latest` (convenience only, not prod) |
+| `v0.6.x` tag | pinned release | `:0.6.x` (semver — what production runs) |
+
+---
+
+## Coordinating API-shape changes across in-flight branches
+
+When multiple stellar-api feature branches change response shapes simultaneously, avoid cascading type drift in stellar-ui:
+
+- Each API branch exports `openapi.json` as part of its PR — do not skip it even for "internal" changes; CI catches it anyway.
+- Regenerate `src/types/api.ts` in stellar-ui (`npm run api:sync`) against the merged spec before merging the UI side.
+- Don't merge an API-touching PR to `main` without the corresponding UI types PR ready to follow promptly — long gaps leave other devs hitting type errors on `main`.
+- If two API branches touch the same shape, coordinate merge order and regenerate types once after the second lands.
+
+---
+
+## Submitting pull requests
+
+- Compose PRs that change `docker-compose.yml` must describe which service changed and why.
+- Submodule-bump and image-pin PRs should reference the API/UI PR(s) or release they incorporate.
+- Environment variable additions must mirror `api/.env.default` (or `ui/.env.example`) and be documented here and in `CLAUDE.md`.
+- Never commit a real secret — the committed `.env.*` files carry `changeme` placeholders; keep live values in your local copies only.


### PR DESCRIPTION
Rescues the two genuinely net-new docs from **PR #12** — `CLAUDE.md` (agent guide) and `CONTRIBUTING.md` (contributor workflow) — reconciled to current reality, so #12 can be closed without losing them.

## Corrections applied while salvaging
- **Production pins a semver, not `:latest`** (ADR-0027) — #12's "`:latest` by default" framing dropped.
- **api type-sync uses `npm run api:sync`** (pulls the sibling spec), not `api:generate`.
- **ui dev server is `npm start`** (Webpack), not `npm run dev`.
- **Submodule-pin note** — pin a *current* api commit (post the self-migrating entrypoint #276); an old pin regresses local builds to manual migration.
- Env var reference points at api `docs/README.md`; a note that live secrets stay local.

## Deliberately NOT carried from #12
- Its **stale api-submodule bump** (`4aabd45`, 2026-06-09 — predates #276, has no self-migrating entrypoint).
- Its **README edits** — the operator runbook lands via **#14** instead.
- Its named-volume / `version:`-drop changes — those land via your local WIP.

Pairs with **#14** (operator runbook + image-ref fixes). Supersedes the doc half of **#12**.