### PR TITLE
chore(compose): bump ui pin to 0.6.9

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,9 @@ services:
     networks:
       - internal
   ui:
-    # 0.6.3 is the latest published stellar-ui image; bump to 0.6.9 once the
-    # ui release cut catches up to the api (version parity). See ADR-0027.
-    image: ghcr.io/orphic-inc/stellar-ui:0.6.3
+    # Pinned to the latest published stellar-ui image (version parity with
+    # the api, per ADR-0027).
+    image: ghcr.io/orphic-inc/stellar-ui:0.6.9
     # build: ./ui
     restart: always
     env_file:


### PR DESCRIPTION
## Summary
- Bumps the `ui` service image pin from `0.6.3` → `0.6.9`, now that stellar-ui has cut a 0.6.9 release for version parity with stellar-api (orphic-inc/stellar-ui#172, plus a CI fix in #173 that restored the GHCR publish job — it had been silently broken since May, which is why 0.6.3 was still the only published image until now).
- Confirmed `ghcr.io/orphic-inc/stellar-ui:0.6.9` is published (`docker manifest inspect` succeeds) before opening this PR.
- Closes the parity note left in compose PR #14 and the first follow-up checkbox in stellar-api issue #313.

## Test plan
- [x] `docker manifest inspect ghcr.io/orphic-inc/stellar-ui:0.6.9` succeeds
- [ ] `docker compose pull ui && docker compose up -d ui` boots cleanly against the new tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)