### PR TITLE
chore(compose): pin db image (closes #8)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,10 @@ services:
       - ./proxy.nginx.conf:/etc/nginx/nginx.conf:ro,Z
       # - ./proxy-tls.nginx.conf:/etc/nginx/nginx.conf:ro,Z
   db:
-    image: postgres:16-alpine
+    # Pinned — the `-alpine` suffix floats the distro, the same drift class that
+    # broke the api Prisma engine (ADR-0001). 16.9 is the current postgres 16
+    # patch; bump deliberately via a reviewed PR, never back to a floating tag.
+    image: postgres:16.9-alpine3.22
     restart: always
     env_file:
       - .env.db


### PR DESCRIPTION
## Summary
Pins the last floating image in the stack: `db: postgres:16-alpine` → **`postgres:16.9-alpine3.22`**. The `-alpine` suffix floats the distro under the tag — the same drift class that advanced api's base to Alpine 3.23 and crash-looped its Prisma engine (ADR-0001, orphic-inc/stellar-api#99/#100). Effectively a no-op today (`16-alpine` already resolves to 16.9) but now reproducible.

With this, all three images are pinned:
- `api: ghcr.io/orphic-inc/stellar-api:0.6.9`
- `ui: ghcr.io/orphic-inc/stellar-ui:0.6.9` (#16)
- `db: postgres:16.9-alpine3.22` (this PR)

Plus the ui **Dockerfile** bases pinned in orphic-inc/stellar-ui (companion PR).

**Closes #8.** Remaining ADR-0001 follow-through stays tracked: Renovate (#9) to keep pins fresh, and the boot smoke test (#7).

## Test plan
- [x] `docker compose config --quiet` passes with the pinned image
- [x] `postgres:16.9-alpine3.22` confirmed pullable

🤖 Generated with [Claude Code](https://claude.com/claude-code)