### PR TITLE
chore(renovate): platformAutomerge off so app merges via bypass

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "platformAutomerge is off deliberately: GitHub native auto-merge ignores the branch-protection app-bypass, so Renovate merges its own automerge PRs directly as the app (the bypass on `main` covers the Renovate app). Required human review stays for everything else; the `validate` required check still gates every merge.",
   "extends": ["config:recommended", ":dependencyDashboard", "schedule:weekly"],
   "prConcurrentLimit": 5,
+  "platformAutomerge": false,
   "packageRules": [
     {
       "description": "Pin GitHub Action digests fresh; safe to automerge",


### PR DESCRIPTION
## Why

Native GitHub auto-merge (`platformAutomerge: true`, the default) **ignores** the branch-protection app-bypass and never triggers the `renovate-approve` helper, so automerge PRs sat `BLOCKED` forever behind the required review.

Setting `platformAutomerge: false` makes Renovate merge its own `automerge: true` PRs **directly via the API as the Renovate app**. The app is in `main`'s `bypass_pull_request_allowances`, so that merge is permitted despite the required review — while:

- humans still need the 1 approving review (only the Renovate *app* bypasses),
- the `validate` required status check still gates every merge (bypass waives review, not checks),
- `automerge: false` classes (base images, Prisma, release pins, majors) are never merged by the bot.

Trade-off vs. native auto-merge: merges land on Renovate's run cadence (minutes–~1h after CI is green) rather than seconds. Acceptable for a bump bot; reliable and fully in our control (no dependency on the opaque `renovate-approve` backend).

Ref: orphic-inc/stellar-compose#9.