### PR TITLE
fix(nginx): stop stripping the /api/ prefix on proxy_pass

### DIFF
--- a/proxy-tls.nginx.conf
+++ b/proxy-tls.nginx.conf
@@ -55,7 +55,7 @@ http {
     location /api/ {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_pass http://api:4056/;
+      proxy_pass http://api:4056;
       proxy_ssl_session_reuse off;
       proxy_set_header Host $http_host;
       proxy_cache_bypass $http_upgrade;

--- a/proxy.nginx.conf
+++ b/proxy.nginx.conf
@@ -20,7 +20,7 @@ http {
     location /api/ {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_pass http://api:8080/;
+      proxy_pass http://api:8080;
       proxy_ssl_session_reuse off;
       proxy_set_header Host $http_host;
       proxy_cache_bypass $http_upgrade;


### PR DESCRIPTION
## Summary
Both `proxy.nginx.conf` and `proxy-tls.nginx.conf` proxy_pass to the api backend with a trailing slash on the URL (`proxy_pass http://api:8080/;`). In nginx, that rewrites away the matched `location /api/` prefix before forwarding — so a request to `/api/auth/login` reaches the backend as `/auth/login`.

api mounts every route under `/api/*` internally:
```
src/app.ts:144:  app.use('/api/auth', authRouter);
src/app.ts:145:  app.use('/api/users', userRouter);
... (all routes, confirmed at the v0.7.0 tag currently pinned in docker-compose.yml)
```
So as currently pinned, every request through this proxy config would 404 against the real api routes — nginx needs to forward the full `/api/...` path unchanged.

## Change
Drop the trailing slash on both `proxy_pass` directives so the full request URI is forwarded as-is.

## Test plan
- [x] Confirmed api's route mounting at the `v0.7.0` tag via `git grep "app.use('/api"` — all routers expect the `/api/` prefix
- [ ] Smoke-test end-to-end against a running stack (not yet done here — static analysis only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)