### PR TITLE
fix(compose): mount db volume at /var/lib/postgresql for postgres 18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,12 @@ services:
       - .env.db
     networks:
       - internal
+    # 18+ images expect a single mount at /var/lib/postgresql (not .../data)
+    # and place data in a major-version-specific subdirectory themselves; see
+    # https://github.com/docker-library/postgres/pull/1259. Mounting at
+    # .../data directly makes the entrypoint refuse to start.
     volumes:
-      - ./volumes/db-data:/var/lib/postgresql/data
+      - ./volumes/db-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 10s


### PR DESCRIPTION
## Summary
As merged (postgres 16-alpine → 18-alpine, #29), `docker-compose.yml` cannot start `db` at all — reproduced locally on both a fresh volume and one with existing data:

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" (specifically, using
       major-version-specific directory names)...
```

Postgres 18's images changed the expected volume convention: a single mount at `/var/lib/postgresql`, with data placed in a version-specific subdirectory the entrypoint manages itself, instead of a mount directly at `.../data` (docker-library/postgres#1259). `api`/`ui` never got a chance to start either, since they depend on `db` being healthy.

## Change
Mount at `/var/lib/postgresql` instead of `/var/lib/postgresql/data`.

## ⚠️ Not an upgrade path
This makes 18 **boot**, nothing more. If anyone has real data sitting in `./volumes/db-data/` from a prior 16.x deployment, it's laid out directly in that directory (`PG_VERSION`, `base/`, etc.) — with this mount-path change, postgres 18 will look for data in a subdirectory of the same mount, **not find the old files, and silently initialize a fresh empty database** next to the orphaned 16 data. Nothing gets deleted, but it'll look like data loss. A real upgrade needs `pg_upgrade` (or dump/restore) run explicitly before/during this transition — this PR doesn't attempt that, it only fixes the mount so 18 can start at all (matches the state before #29, where nobody could get past `db` failing to start anyway).

## Test plan
- [x] Fresh volume: `db` reports healthy, 28 pending migrations apply cleanly, seed runs, `api` boots
- [x] Confirmed end-to-end through nginx: `curl http://localhost/api/version` → `200 {"version":"0.7.0"}`
- [ ] Verify no one has an existing populated 16.x volume depending on this repo's compose file before merging (see caveat above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)